### PR TITLE
[ADJUSTMENT] - Repeat size snapping changes to PixelSnapCenter and PixelSnapAlign (forgot to do this).

### DIFF
--- a/test/flutter/pixel_snapping_test.dart
+++ b/test/flutter/pixel_snapping_test.dart
@@ -35,7 +35,7 @@ void main() {
         tester.getTopLeft(find.byKey(contentKey)),
         Offset(25, 25),
       );
-      expect(tester.getSize(find.byKey(contentKey)), Size(49, 49));
+      expect(tester.getSize(find.byKey(contentKey)), Size(50, 50));
     });
 
     testWidgets("PixelSnapAlign", (tester) async {
@@ -69,7 +69,7 @@ void main() {
         tester.getTopLeft(find.byKey(contentKey)),
         Offset(13, 13),
       );
-      expect(tester.getSize(find.byKey(contentKey)), Size(49, 49));
+      expect(tester.getSize(find.byKey(contentKey)), Size(50, 50));
     });
 
     testWidgets("PixelSnapRow", (tester) async {


### PR DESCRIPTION
This is a continuation of #67 because I forgot to apply size snapping to `PixelSnapCenter` and `PixelSnapAlign`.