### PR TITLE
[Adjustment] - Add more reporting to test output to help locate failure files and to summarize overall test run (Resolves #64)

### DIFF
--- a/lib/flutter_test_goldens.dart
+++ b/lib/flutter_test_goldens.dart
@@ -19,4 +19,4 @@ export 'src/scenes/layouts/row_and_column_layout.dart';
 export 'src/scenes/scene_layout.dart';
 export 'src/scenes/single_shot.dart';
 export 'src/logging.dart';
-export 'src/test_runners.dart';
+export 'src/test_runner/test_runners.dart';

--- a/lib/src/scenes/gallery.dart
+++ b/lib/src/scenes/gallery.dart
@@ -651,6 +651,7 @@ Image.memory(
     }
 
     if (mismatches.mismatches.isEmpty) {
+      // Report this scene's successes to overall test run reporter.
       testRunReporter.recordGoldenPassesAndFailures(
         passed: candidateCollection.length,
         failed: 0,

--- a/lib/src/scenes/gallery.dart
+++ b/lib/src/scenes/gallery.dart
@@ -5,13 +5,14 @@ import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Image;
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_test_goldens/flutter_test_goldens.dart';
 import 'package:flutter_test_goldens/src/flutter/flutter_camera.dart';
 import 'package:flutter_test_goldens/src/flutter/flutter_test_extensions.dart';
+import 'package:flutter_test_goldens/src/fonts/fonts.dart';
 import 'package:flutter_test_goldens/src/goldens/golden_collections.dart';
 import 'package:flutter_test_goldens/src/goldens/golden_comparisons.dart';
 import 'package:flutter_test_goldens/src/goldens/golden_rendering.dart';
 import 'package:flutter_test_goldens/src/goldens/golden_scenes.dart';
+import 'package:flutter_test_goldens/src/test_runner/test_run_reporter.dart';
 import 'package:flutter_test_goldens/src/logging.dart';
 import 'package:flutter_test_goldens/src/png/png_metadata.dart';
 import 'package:flutter_test_goldens/src/scenes/failure_scene.dart';
@@ -19,7 +20,7 @@ import 'package:flutter_test_goldens/src/scenes/golden_scene.dart';
 import 'package:flutter_test_goldens/src/scenes/golden_scene_report_printer.dart';
 import 'package:flutter_test_goldens/src/scenes/scene_layout.dart';
 import 'package:image/image.dart';
-import 'package:path/path.dart';
+import 'package:path/path.dart' as path;
 
 /// A golden builder that builds independent widget tree UIs and then either
 /// renders those into a single scene file, or compares them against an existing
@@ -642,6 +643,10 @@ Image.memory(
     }
 
     if (mismatches.mismatches.isEmpty) {
+      GoldenTestRunReporter.instance.recordGoldenPassesAndFailures(
+        passed: candidateCollection.length,
+        failed: 0,
+      );
       FtgLog.pipeline.info("No golden mismatches found");
       return;
     }
@@ -655,6 +660,7 @@ Image.memory(
     );
 
     Directory(_goldenFailureDirectoryPath).createSync();
+    final failureFile = File("$_goldenFailureDirectoryPath/failure_$existingGoldenFileName.png");
 
     await tester.runAsync(() async {
       final (failureImage, metadata) = await paintFailureScene(tester, report);
@@ -665,11 +671,18 @@ Image.memory(
         const JsonEncoder().convert(metadata.toJson()),
       );
 
-      final file = File("$_goldenFailureDirectoryPath/failure_$existingGoldenFileName.png");
-      file.writeAsBytesSync(pngData);
+      failureFile.writeAsBytesSync(pngData);
     });
 
-    _printReport(report);
+    GoldenTestRunReporter.instance.recordGoldenPassesAndFailures(
+      passed: report.totalPassed,
+      failed: report.totalFailed + report.missingCandidates.length + report.extraCandidates.length,
+    );
+    _printReport(
+      report,
+      goldenFilePath: path.normalize(goldenFile.path),
+      failureFilePaths: [path.normalize(failureFile.path)],
+    );
 
     if (mismatches.mismatches.isNotEmpty) {
       fail("Goldens failed with ${mismatches.mismatches.length} mismatch(es)");
@@ -679,7 +692,7 @@ Image.memory(
   // TODO: Dedup following with Timeline
   String get _testFileDirectory => (goldenFileComparator as LocalFileComparator).basedir.path;
 
-  String get _goldenDirectory => "$_testFileDirectory${_directory.path}$separator";
+  String get _goldenDirectory => "$_testFileDirectory${_directory.path}${path.separator}";
 
   /// Calculates and returns a complete file path to the golden file specified by
   /// this gallery, which consists of the current test file directory + an optional
@@ -690,8 +703,16 @@ Image.memory(
   String get _goldenFailureDirectoryPath => "${_goldenDirectory}failures";
 
   /// Prints the report in an human readable format to the console.
-  void _printReport(GoldenSceneReport report) {
-    GoldenSceneReportPrinter().printReport(report);
+  void _printReport(
+    GoldenSceneReport report, {
+    required String goldenFilePath,
+    required List<String> failureFilePaths,
+  }) {
+    GoldenSceneReportPrinter().printReport(
+      report,
+      goldenFilePath: goldenFilePath,
+      failureFilePaths: failureFilePaths,
+    );
   }
 }
 

--- a/lib/src/scenes/gallery.dart
+++ b/lib/src/scenes/gallery.dart
@@ -605,6 +605,7 @@ Image.memory(
     final items = <GoldenReport>[];
     final missingCandidates = <MissingCandidateMismatch>[];
     final extraCandidates = <MissingGoldenMismatch>[];
+    final goldenFilePath = path.normalize(goldenFile.path);
 
     FtgLog.pipeline.fine("Mismatches ($existingGoldenFileName):");
     for (final mismatch in mismatches.mismatches.values) {
@@ -637,7 +638,10 @@ Image.memory(
       if (mismatch == null) {
         // The golden check passed.
         items.add(
-          GoldenReport.success(goldenMetadata),
+          GoldenReport.success(
+            goldenMetadata,
+            goldenFilePath: goldenFilePath,
+          ),
         );
       } else {
         // The golden check failed.
@@ -645,6 +649,7 @@ Image.memory(
           GoldenReport.failure(
             metadata: goldenMetadata,
             mismatch: mismatch,
+            goldenFilePath: goldenFilePath,
           ),
         );
       }
@@ -661,15 +666,26 @@ Image.memory(
     }
 
     FtgLog.pipeline.info("Found ${mismatches.mismatches.length} golden mismatches in scene.");
+    Directory(_goldenFailureDirectoryPath).createSync();
+    final failureFile = File("$_goldenFailureDirectoryPath/failure_$existingGoldenFileName.png");
+    final failureFilePath = path.normalize(failureFile.path);
     final report = GoldenSceneReport(
       metadata: metadata,
-      items: items,
+      items: [
+        for (final item in items)
+          if (item.status == GoldenTestStatus.failure)
+            GoldenReport.failure(
+              metadata: item.metadata,
+              mismatch: item.mismatch!,
+              goldenFilePath: item.goldenFilePath,
+              failureFilePaths: [failureFilePath],
+            )
+          else
+            item,
+      ],
       missingCandidates: missingCandidates,
       extraCandidates: extraCandidates,
     );
-
-    Directory(_goldenFailureDirectoryPath).createSync();
-    final failureFile = File("$_goldenFailureDirectoryPath/failure_$existingGoldenFileName.png");
 
     await tester.runAsync(() async {
       final (failureImage, metadata) = await paintFailureScene(tester, report);
@@ -684,11 +700,7 @@ Image.memory(
     });
 
     // Report success/failures in this scene.
-    GoldenSceneReportPrinter().printReport(
-      report,
-      goldenFilePath: path.normalize(goldenFile.path),
-      failureFilePaths: [path.normalize(failureFile.path)],
-    );
+    GoldenSceneReportPrinter().printReport(report);
 
     // Log the number of passed/failed goldens in this scene for the overall
     // test run report.

--- a/lib/src/scenes/gallery.dart
+++ b/lib/src/scenes/gallery.dart
@@ -682,14 +682,18 @@ Image.memory(
       failureFile.writeAsBytesSync(pngData);
     });
 
-    testRunReporter.recordGoldenPassesAndFailures(
-      passed: report.totalPassed,
-      failed: report.totalFailed + report.missingCandidates.length + report.extraCandidates.length,
-    );
-    _printReport(
+    // Report success/failures in this scene.
+    GoldenSceneReportPrinter().printReport(
       report,
       goldenFilePath: path.normalize(goldenFile.path),
       failureFilePaths: [path.normalize(failureFile.path)],
+    );
+
+    // Log the number of passed/failed goldens in this scene for the overall
+    // test run report.
+    testRunReporter.recordGoldenPassesAndFailures(
+      passed: report.totalPassed,
+      failed: report.totalFailed + report.missingCandidates.length + report.extraCandidates.length,
     );
 
     if (mismatches.mismatches.isNotEmpty) {
@@ -709,19 +713,6 @@ Image.memory(
       "$_goldenDirectory$_fileName${includeExtension ? ".png" : ""}";
 
   String get _goldenFailureDirectoryPath => "${_goldenDirectory}failures";
-
-  /// Prints the report in an human readable format to the console.
-  void _printReport(
-    GoldenSceneReport report, {
-    required String goldenFilePath,
-    required List<String> failureFilePaths,
-  }) {
-    GoldenSceneReportPrinter().printReport(
-      report,
-      goldenFilePath: goldenFilePath,
-      failureFilePaths: failureFilePaths,
-    );
-  }
 }
 
 /// A request for a single UI screenshot within a gallery of independent screenshots.

--- a/lib/src/scenes/gallery.dart
+++ b/lib/src/scenes/gallery.dart
@@ -298,8 +298,10 @@ class Gallery {
   Future<void> run(
     WidgetTester tester, {
     FlutterCamera? camera,
+    GoldenTestRunReporter? testRunReporter,
   }) async {
     FtgLog.pipeline.info("Rendering or comparing golden - $_sceneDescription");
+    testRunReporter ??= GoldenTestRunReporter.instance;
 
     // Build each golden tree and take `FlutterScreenshot`s.
     camera ??= FlutterCamera();
@@ -323,7 +325,12 @@ class Gallery {
       // Compare to existing goldens.
       FtgLog.pipeline.finer("Comparing existing goldens...");
       // TODO: Return a success/failure report that we can publish to the test output.
-      await _compareGoldens(tester, _fileName, screenshots);
+      await _compareGoldens(
+        tester,
+        _fileName,
+        screenshots,
+        testRunReporter: testRunReporter,
+      );
       FtgLog.pipeline.finer("Done comparing goldens.");
     }
 
@@ -565,8 +572,9 @@ Image.memory(
   Future<void> _compareGoldens(
     WidgetTester tester,
     String existingGoldenFileName,
-    Map<String, GoldenSceneScreenshot> candidateCollection,
-  ) async {
+    Map<String, GoldenSceneScreenshot> candidateCollection, {
+    required GoldenTestRunReporter testRunReporter,
+  }) async {
     // Extract scene metadata and golden images from image file.
     FtgLog.pipeline.fine("Extracting golden collection from scene file (goldens).");
     final goldenFile = File(_goldenFilePath());
@@ -643,7 +651,7 @@ Image.memory(
     }
 
     if (mismatches.mismatches.isEmpty) {
-      GoldenTestRunReporter.instance.recordGoldenPassesAndFailures(
+      testRunReporter.recordGoldenPassesAndFailures(
         passed: candidateCollection.length,
         failed: 0,
       );
@@ -674,7 +682,7 @@ Image.memory(
       failureFile.writeAsBytesSync(pngData);
     });
 
-    GoldenTestRunReporter.instance.recordGoldenPassesAndFailures(
+    testRunReporter.recordGoldenPassesAndFailures(
       passed: report.totalPassed,
       failed: report.totalFailed + report.missingCandidates.length + report.extraCandidates.length,
     );

--- a/lib/src/scenes/golden_scene.dart
+++ b/lib/src/scenes/golden_scene.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' show Colors, MaterialApp, Scaffold, ThemeData, Theme;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -366,32 +365,43 @@ class GoldenSceneReport {
 ///
 /// A [GoldenReport] holds the test results for a candidate that has a corresponding golden.
 class GoldenReport {
-  factory GoldenReport.success(GoldenImageMetadata metadata) {
+  factory GoldenReport.success(
+    GoldenImageMetadata metadata, {
+    required String goldenFilePath,
+  }) {
     return GoldenReport(
       status: GoldenTestStatus.success,
       metadata: metadata,
+      goldenFilePath: goldenFilePath,
     );
   }
 
   factory GoldenReport.failure({
     required GoldenImageMetadata metadata,
     required GoldenMismatch mismatch,
+    required String goldenFilePath,
+    List<String> failureFilePaths = const [],
   }) {
     return GoldenReport(
       status: GoldenTestStatus.failure,
       metadata: metadata,
       mismatch: mismatch,
+      goldenFilePath: goldenFilePath,
+      failureFilePaths: failureFilePaths,
     );
   }
 
   GoldenReport({
     required this.status,
     required this.metadata,
+    required this.goldenFilePath,
     this.mismatch,
-  }) : assert(
+    List<String> failureFilePaths = const [],
+  })  : assert(
           status == GoldenTestStatus.success || mismatch != null,
           "A failure report must have a mismatch.",
-        );
+        ),
+        failureFilePaths = List.unmodifiable(failureFilePaths);
 
   /// Whether the gallery item passed or failed the golden check.
   final GoldenTestStatus status;
@@ -403,6 +413,12 @@ class GoldenReport {
   ///
   /// Non-`null` if [status] is [GoldenTestStatus.failure] and `null` otherwise.
   final GoldenMismatch? mismatch;
+
+  /// The path to the golden file that this item was compared against.
+  final String goldenFilePath;
+
+  /// The paths to any failure scene files that were written for this item.
+  final List<String> failureFilePaths;
 }
 
 enum GoldenTestStatus {

--- a/lib/src/scenes/golden_scene_report_printer.dart
+++ b/lib/src/scenes/golden_scene_report_printer.dart
@@ -1,7 +1,12 @@
 import 'package:flutter_test_goldens/flutter_test_goldens.dart';
 
 class GoldenSceneReportPrinter {
-  void printReport(GoldenSceneReport report) {
+  void printReport(
+    GoldenSceneReport report, {
+    required String goldenFilePath,
+    required List<String> failureFilePaths,
+    StringSink? output,
+  }) {
     if (report.totalFailed == 0 && //
         report.missingCandidates.isEmpty &&
         report.extraCandidates.isEmpty) {
@@ -30,6 +35,19 @@ class GoldenSceneReportPrinter {
       }
     }
     buffer.writeln("):");
+    buffer.writeln("Scene: ${report.metadata.description}");
+    buffer.writeln("Golden file: $goldenFilePath");
+    if (failureFilePaths.isEmpty) {
+      buffer.writeln("Failure scene: No failure scene was written.");
+    } else if (failureFilePaths.length == 1) {
+      buffer.writeln("Failure scene: ${failureFilePaths.single}");
+    } else {
+      buffer.writeln("Failure scenes:");
+      for (final failureFilePath in failureFilePaths) {
+        buffer.writeln("  - $failureFilePath");
+      }
+    }
+    buffer.writeln("");
 
     if (report.totalFailed > 0) {
       for (final item in report.items) {
@@ -101,7 +119,11 @@ class GoldenSceneReportPrinter {
       }
     }
 
-    // ignore: avoid_print
-    print(buffer.toString());
+    if (output != null) {
+      output.write(buffer.toString());
+    } else {
+      // ignore: avoid_print
+      print(buffer.toString());
+    }
   }
 }

--- a/lib/src/scenes/golden_scene_report_printer.dart
+++ b/lib/src/scenes/golden_scene_report_printer.dart
@@ -3,8 +3,6 @@ import 'package:flutter_test_goldens/flutter_test_goldens.dart';
 class GoldenSceneReportPrinter {
   void printReport(
     GoldenSceneReport report, {
-    required String goldenFilePath,
-    required List<String> failureFilePaths,
     StringSink? output,
   }) {
     if (report.totalFailed == 0 && //
@@ -36,7 +34,17 @@ class GoldenSceneReportPrinter {
     }
     buffer.writeln("):");
     buffer.writeln("Scene: ${report.metadata.description}");
-    buffer.writeln("Golden file: $goldenFilePath");
+    final goldenFilePaths = report.items.map((item) => item.goldenFilePath).toSet().toList(growable: false);
+    if (goldenFilePaths.length == 1) {
+      buffer.writeln("Golden file: ${goldenFilePaths.single}");
+    } else if (goldenFilePaths.length > 1) {
+      buffer.writeln("Golden files:");
+      for (final goldenFilePath in goldenFilePaths) {
+        buffer.writeln("  - $goldenFilePath");
+      }
+    }
+
+    final failureFilePaths = report.items.expand((item) => item.failureFilePaths).toSet().toList(growable: false);
     if (failureFilePaths.isEmpty) {
       buffer.writeln("Failure scene: No failure scene was written.");
     } else if (failureFilePaths.length == 1) {

--- a/lib/src/scenes/timeline.dart
+++ b/lib/src/scenes/timeline.dart
@@ -548,7 +548,8 @@ class Timeline {
         });
       }
 
-      final report = _buildReport(
+      // Print a report for this scene.
+      final sceneReport = _createSceneReport(
         sceneMetadata,
         goldenCollection,
         screenshotCollection,
@@ -558,12 +559,13 @@ class Timeline {
           (id, failureFilePath) => MapEntry(id, path.normalize(failureFilePath)),
         ),
       );
+      GoldenSceneReportPrinter().printReport(sceneReport);
 
+      // Report our success/failure numbers to the overall test run report.
       testRunReporter.recordGoldenPassesAndFailures(
-        passed: report.totalPassed,
-        failed: report.totalFailed + report.missingCandidates.length + report.extraCandidates.length,
+        passed: sceneReport.totalPassed,
+        failed: sceneReport.totalFailed + sceneReport.missingCandidates.length + sceneReport.extraCandidates.length,
       );
-      GoldenSceneReportPrinter().printReport(report);
 
       throw Exception("Goldens failed with ${mismatches.mismatches.length} mismatch(es)");
     } else {
@@ -585,7 +587,7 @@ class Timeline {
 
   String get _goldenFailureDirectoryPath => "${_goldenDirectory}failures";
 
-  GoldenSceneReport _buildReport(
+  GoldenSceneReport _createSceneReport(
     GoldenSceneMetadata metadata,
     ScreenshotCollection goldenCollection,
     ScreenshotCollection screenshotCollection,

--- a/lib/src/scenes/timeline.dart
+++ b/lib/src/scenes/timeline.dart
@@ -220,13 +220,17 @@ class Timeline {
     return this;
   }
 
-  Future<void> run(WidgetTester tester) async {
+  Future<void> run(
+    WidgetTester tester, {
+    GoldenTestRunReporter? testRunReporter,
+  }) async {
     if (_setup == null) {
       throw Exception(
           "Can't render or compare golden file without a setup action. Please call setup() or setupWithPump().");
     }
 
     FtgLog.pipeline.info("Rendering or comparing golden - $_fileName");
+    testRunReporter ??= GoldenTestRunReporter.instance;
 
     // Always operate at a 1:1 logical-to-physical pixel ratio to help reduce
     // anti-aliasing and other artifacts from fractional pixel offsets.
@@ -335,6 +339,7 @@ class Timeline {
         sceneMetadata,
         relativeGoldenFilePath,
         find.byType(GoldenSceneBounds),
+        testRunReporter: testRunReporter,
       );
     }
 
@@ -428,8 +433,9 @@ class Timeline {
     WidgetTester tester,
     GoldenSceneMetadata sceneMetadata,
     String relativeGoldenFilePath,
-    Finder goldenBounds,
-  ) async {
+    Finder goldenBounds, {
+    required GoldenTestRunReporter testRunReporter,
+  }) async {
     FtgLog.pipeline.finer("Comparing existing goldens...");
 
     FtgLog.pipeline.fine("Extracting golden collection from scene file (goldens).");
@@ -553,7 +559,7 @@ class Timeline {
         ),
       );
 
-      GoldenTestRunReporter.instance.recordGoldenPassesAndFailures(
+      testRunReporter.recordGoldenPassesAndFailures(
         passed: report.totalPassed,
         failed: report.totalFailed + report.missingCandidates.length + report.extraCandidates.length,
       );
@@ -561,7 +567,7 @@ class Timeline {
 
       throw Exception("Goldens failed with ${mismatches.mismatches.length} mismatch(es)");
     } else {
-      GoldenTestRunReporter.instance.recordGoldenPassesAndFailures(
+      testRunReporter.recordGoldenPassesAndFailures(
         passed: screenshotCollection.screenshotsById.length,
         failed: 0,
       );

--- a/lib/src/scenes/timeline.dart
+++ b/lib/src/scenes/timeline.dart
@@ -454,8 +454,7 @@ class Timeline {
         FtgLog.pipeline.fine(" - ${mismatch.golden?.id ?? mismatch.screenshot?.id}: $mismatch");
       }
 
-      final report = _buildReport(sceneMetadata, goldenCollection, screenshotCollection, mismatches);
-      final failureFilePaths = <String>[];
+      final failureFilePathsByGoldenId = <String, String>{};
 
       for (final mismatch in mismatches.mismatches.values) {
         if (mismatch.golden == null || mismatch.screenshot == null) {
@@ -538,20 +537,27 @@ class Timeline {
           }
 
           final failureFilePath = "${failureDirectory.path}/failure_${_fileName}_${mismatch.golden!.id}.png";
-          failureFilePaths.add(failureFilePath);
+          failureFilePathsByGoldenId[mismatch.golden!.id] = failureFilePath;
           await encodePngFile(failureFilePath, failureImage);
         });
       }
+
+      final report = _buildReport(
+        sceneMetadata,
+        goldenCollection,
+        screenshotCollection,
+        mismatches,
+        goldenFilePath: path.normalize(goldenFile.path),
+        failureFilePathsByGoldenId: failureFilePathsByGoldenId.map(
+          (id, failureFilePath) => MapEntry(id, path.normalize(failureFilePath)),
+        ),
+      );
 
       GoldenTestRunReporter.instance.recordGoldenPassesAndFailures(
         passed: report.totalPassed,
         failed: report.totalFailed + report.missingCandidates.length + report.extraCandidates.length,
       );
-      GoldenSceneReportPrinter().printReport(
-        report,
-        goldenFilePath: path.normalize(goldenFile.path),
-        failureFilePaths: failureFilePaths.map(path.normalize).toList(growable: false),
-      );
+      GoldenSceneReportPrinter().printReport(report);
 
       throw Exception("Goldens failed with ${mismatches.mismatches.length} mismatch(es)");
     } else {
@@ -577,8 +583,10 @@ class Timeline {
     GoldenSceneMetadata metadata,
     ScreenshotCollection goldenCollection,
     ScreenshotCollection screenshotCollection,
-    GoldenCollectionMismatches mismatches,
-  ) {
+    GoldenCollectionMismatches mismatches, {
+    required String goldenFilePath,
+    required Map<String, String> failureFilePathsByGoldenId,
+  }) {
     final items = <GoldenReport>[];
     final missingCandidates = <MissingCandidateMismatch>[];
     final extraCandidates = <MissingGoldenMismatch>[];
@@ -602,11 +610,18 @@ class Timeline {
       final imageMetadata = metadata.images.where((image) => image.id == screenshotId).first;
       final mismatch = mismatches.mismatches[screenshotId];
       if (mismatch == null) {
-        items.add(GoldenReport.success(imageMetadata));
+        items.add(GoldenReport.success(
+          imageMetadata,
+          goldenFilePath: goldenFilePath,
+        ));
       } else {
         items.add(GoldenReport.failure(
           metadata: imageMetadata,
           mismatch: mismatch,
+          goldenFilePath: goldenFilePath,
+          failureFilePaths: [
+            if (failureFilePathsByGoldenId[screenshotId] != null) failureFilePathsByGoldenId[screenshotId]!,
+          ],
         ));
       }
     }

--- a/lib/src/scenes/timeline.dart
+++ b/lib/src/scenes/timeline.dart
@@ -13,13 +13,15 @@ import 'package:flutter_test_goldens/src/goldens/golden_comparisons.dart';
 import 'package:flutter_test_goldens/src/goldens/golden_rendering.dart';
 import 'package:flutter_test_goldens/src/goldens/golden_scenes.dart';
 import 'package:flutter_test_goldens/src/goldens/pixel_comparisons.dart';
+import 'package:flutter_test_goldens/src/test_runner/test_run_reporter.dart';
 import 'package:flutter_test_goldens/src/logging.dart';
 import 'package:flutter_test_goldens/src/png/png_metadata.dart';
+import 'package:flutter_test_goldens/src/scenes/golden_scene_report_printer.dart';
 import 'package:flutter_test_goldens/src/scenes/golden_scene.dart';
 import 'package:flutter_test_goldens/src/scenes/scene_layout.dart';
 import 'package:golden_bricks/golden_bricks.dart';
 import 'package:image/image.dart' hide Color;
-import 'package:path/path.dart';
+import 'package:path/path.dart' as path;
 
 /// A golden builder that takes screenshots over a period of time and
 /// stitches them together into a single golden file with a given
@@ -452,6 +454,9 @@ class Timeline {
         FtgLog.pipeline.fine(" - ${mismatch.golden?.id ?? mismatch.screenshot?.id}: $mismatch");
       }
 
+      final report = _buildReport(sceneMetadata, goldenCollection, screenshotCollection, mismatches);
+      final failureFilePaths = <String>[];
+
       for (final mismatch in mismatches.mismatches.values) {
         if (mismatch.golden == null || mismatch.screenshot == null) {
           continue;
@@ -532,15 +537,28 @@ class Timeline {
             }
           }
 
-          await encodePngFile(
-            "${failureDirectory.path}/failure_${_fileName}_${mismatch.golden!.id}.png",
-            failureImage,
-          );
+          final failureFilePath = "${failureDirectory.path}/failure_${_fileName}_${mismatch.golden!.id}.png";
+          failureFilePaths.add(failureFilePath);
+          await encodePngFile(failureFilePath, failureImage);
         });
       }
 
+      GoldenTestRunReporter.instance.recordGoldenPassesAndFailures(
+        passed: report.totalPassed,
+        failed: report.totalFailed + report.missingCandidates.length + report.extraCandidates.length,
+      );
+      GoldenSceneReportPrinter().printReport(
+        report,
+        goldenFilePath: path.normalize(goldenFile.path),
+        failureFilePaths: failureFilePaths.map(path.normalize).toList(growable: false),
+      );
+
       throw Exception("Goldens failed with ${mismatches.mismatches.length} mismatch(es)");
     } else {
+      GoldenTestRunReporter.instance.recordGoldenPassesAndFailures(
+        passed: screenshotCollection.screenshotsById.length,
+        failed: 0,
+      );
       FtgLog.pipeline.info("No golden mismatches found");
     }
 
@@ -549,11 +567,57 @@ class Timeline {
 
   String get _testFileDirectory => (goldenFileComparator as LocalFileComparator).basedir.path;
 
-  String get _goldenDirectory => "$_testFileDirectory$_relativeGoldenDirectory$separator";
+  String get _goldenDirectory => "$_testFileDirectory$_relativeGoldenDirectory${path.separator}";
 
   String get _relativeGoldenDirectory => _directory?.path ?? GoldenSceneTheme.current.directory.path;
 
   String get _goldenFailureDirectoryPath => "${_goldenDirectory}failures";
+
+  GoldenSceneReport _buildReport(
+    GoldenSceneMetadata metadata,
+    ScreenshotCollection goldenCollection,
+    ScreenshotCollection screenshotCollection,
+    GoldenCollectionMismatches mismatches,
+  ) {
+    final items = <GoldenReport>[];
+    final missingCandidates = <MissingCandidateMismatch>[];
+    final extraCandidates = <MissingGoldenMismatch>[];
+
+    for (final mismatch in mismatches.mismatches.values) {
+      switch (mismatch) {
+        case MissingCandidateMismatch():
+          missingCandidates.add(mismatch);
+          break;
+        case MissingGoldenMismatch():
+          extraCandidates.add(mismatch);
+          break;
+      }
+    }
+
+    for (final screenshotId in screenshotCollection.ids) {
+      if (!goldenCollection.hasId(screenshotId)) {
+        continue;
+      }
+
+      final imageMetadata = metadata.images.where((image) => image.id == screenshotId).first;
+      final mismatch = mismatches.mismatches[screenshotId];
+      if (mismatch == null) {
+        items.add(GoldenReport.success(imageMetadata));
+      } else {
+        items.add(GoldenReport.failure(
+          metadata: imageMetadata,
+          mismatch: mismatch,
+        ));
+      }
+    }
+
+    return GoldenSceneReport(
+      metadata: metadata,
+      items: items,
+      missingCandidates: missingCandidates,
+      extraCandidates: extraCandidates,
+    );
+  }
 
   /// Calculates and returns a complete file path to the golden file specified by
   /// this gallery, which consists of the current test file directory + an optional

--- a/lib/src/test_runner/test_run_reporter.dart
+++ b/lib/src/test_runner/test_run_reporter.dart
@@ -1,0 +1,30 @@
+/// Writes a report for an entire golden test run, which might include any
+/// number of golden scenes and golden test files.
+class GoldenTestRunReporter {
+  static final instance = GoldenTestRunReporter();
+
+  var _passed = 0;
+  var _failed = 0;
+
+  void recordGoldenPassesAndFailures({
+    required int passed,
+    required int failed,
+  }) {
+    _passed += passed;
+    _failed += failed;
+  }
+
+  void printSummary({StringSink? output}) {
+    if (_passed == 0 && _failed == 0) {
+      return;
+    }
+
+    final summary = "Golden Tests: $_passed Passed, $_failed Failed";
+    if (output != null) {
+      output.writeln(summary);
+    } else {
+      // ignore: avoid_print
+      print(summary);
+    }
+  }
+}

--- a/lib/src/test_runner/test_runners.dart
+++ b/lib/src/test_runner/test_runners.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_test_goldens/src/fonts/fonts.dart';
+import 'package:flutter_test_goldens/src/test_runner/test_run_reporter.dart';
 import 'package:meta/meta.dart';
 
 /// Annotation for tests that generate a golden scene, which allows them to be easily
@@ -248,6 +248,14 @@ void testGoldenScene(
   dynamic tags,
   int? retry,
 }) {
+  if (!_didRegisterGoldenTestRunSummary) {
+    _didRegisterGoldenTestRunSummary = true;
+
+    // After all golden tests and golden scenes are run, print a report for the
+    // entire test run with the golden pass and failure counts.
+    tearDownAll(GoldenTestRunReporter.instance.printSummary);
+  }
+
   testWidgets(
     description,
     (tester) async {
@@ -269,3 +277,12 @@ void testGoldenScene(
     retry: retry,
   );
 }
+
+/// Whether the current running test suite has scheduled itself to print a
+/// summary during `tearDownAll()`.
+///
+/// Once set to `true`, this will never be set to `false` because we expect
+/// a single test run execution to run a single set of tests, which means
+/// a followup test run should spin up a new process with this value once
+/// again initializing to `false`.
+var _didRegisterGoldenTestRunSummary = false;

--- a/test/test_runner/reporting_test.dart
+++ b/test/test_runner/reporting_test.dart
@@ -1,0 +1,112 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_goldens/src/goldens/golden_collections.dart';
+import 'package:flutter_test_goldens/src/goldens/golden_comparisons.dart';
+import 'package:flutter_test_goldens/src/goldens/golden_scenes.dart';
+import 'package:flutter_test_goldens/src/scenes/golden_scene.dart';
+import 'package:flutter_test_goldens/src/scenes/golden_scene_report_printer.dart';
+import 'package:flutter_test_goldens/src/test_runner/test_run_reporter.dart';
+import 'package:image/image.dart' as img;
+
+void main() {
+  group("Golden reporting >", () {
+    test("prints scene details and whole-run golden totals", () {
+      final topGolden = _screenshot("Top (Constrained)");
+      final topCandidate = _screenshot("Top (Constrained)");
+      final rightGolden = _screenshot("Right (Constrained)");
+      final rightCandidate = _screenshot("Right (Constrained)");
+
+      final report = GoldenSceneReport(
+        metadata: GoldenSceneMetadata(
+          description: "Follower > preferred position aligner > not enough space on either side",
+          images: [
+            _imageMetadata("Left (Constrained)"),
+            _imageMetadata("Top (Constrained)"),
+            _imageMetadata("Right (Constrained)"),
+            _imageMetadata("Bottom (Constrained)"),
+          ],
+        ),
+        items: [
+          GoldenReport.success(_imageMetadata("Left (Constrained)")),
+          GoldenReport.failure(
+            metadata: _imageMetadata("Top (Constrained)"),
+            mismatch: PixelGoldenMismatch(
+              golden: topGolden,
+              screenshot: topCandidate,
+              mismatchPixelCount: 240,
+            ),
+          ),
+          GoldenReport.failure(
+            metadata: _imageMetadata("Right (Constrained)"),
+            mismatch: PixelGoldenMismatch(
+              golden: rightGolden,
+              screenshot: rightCandidate,
+              mismatchPixelCount: 220,
+            ),
+          ),
+          GoldenReport.success(_imageMetadata("Bottom (Constrained)")),
+        ],
+        missingCandidates: const [],
+        extraCandidates: const [],
+      );
+
+      final reporter = GoldenTestRunReporter()
+        ..recordGoldenPassesAndFailures(passed: 2, failed: 1)
+        ..recordGoldenPassesAndFailures(passed: 3, failed: 0)
+        ..recordGoldenPassesAndFailures(passed: 29, failed: 11);
+
+      final output = StringBuffer();
+      GoldenSceneReportPrinter().printReport(
+        report,
+        goldenFilePath: "/project/test_goldens/preferred_position_aligner.png",
+        failureFilePaths: [
+          "/project/test_goldens/failures/failure_preferred_position_aligner_top.png",
+          "/project/test_goldens/failures/failure_preferred_position_aligner_right.png",
+        ],
+        output: output,
+      );
+      reporter.printSummary(output: output);
+
+      expect(output.toString(), '''
+Golden scene failed (✅ 2/4, ❌ 2/4):
+Scene: Follower > preferred position aligner > not enough space on either side
+Golden file: /project/test_goldens/preferred_position_aligner.png
+Failure scenes:
+  - /project/test_goldens/failures/failure_preferred_position_aligner_top.png
+  - /project/test_goldens/failures/failure_preferred_position_aligner_right.png
+
+✅ Left (Constrained)
+❌ Top (Constrained) (240px, 2.40%)
+❌ Right (Constrained) (220px, 2.20%)
+✅ Bottom (Constrained)
+Golden Tests: 34 Passed, 12 Failed
+''');
+    });
+  });
+}
+
+GoldenImageMetadata _imageMetadata(String id) {
+  return GoldenImageMetadata(
+    id: id,
+    metadata: GoldenScreenshotMetadata(
+      description: id,
+      simulatedPlatform: TargetPlatform.android,
+    ),
+    topLeft: ui.Offset.zero,
+    size: const ui.Size(100, 100),
+  );
+}
+
+GoldenSceneScreenshot _screenshot(String id) {
+  return GoldenSceneScreenshot(
+    id,
+    GoldenScreenshotMetadata(
+      description: id,
+      simulatedPlatform: TargetPlatform.android,
+    ),
+    img.Image(width: 100, height: 100),
+    Uint8List(0),
+  );
+}

--- a/test/test_runner/reporting_test.dart
+++ b/test/test_runner/reporting_test.dart
@@ -29,7 +29,10 @@ void main() {
           ],
         ),
         items: [
-          GoldenReport.success(_imageMetadata("Left (Constrained)")),
+          GoldenReport.success(
+            _imageMetadata("Left (Constrained)"),
+            goldenFilePath: "/project/test_goldens/preferred_position_aligner.png",
+          ),
           GoldenReport.failure(
             metadata: _imageMetadata("Top (Constrained)"),
             mismatch: PixelGoldenMismatch(
@@ -37,6 +40,8 @@ void main() {
               screenshot: topCandidate,
               mismatchPixelCount: 240,
             ),
+            goldenFilePath: "/project/test_goldens/preferred_position_aligner.png",
+            failureFilePaths: ["/project/test_goldens/failures/failure_preferred_position_aligner_top.png"],
           ),
           GoldenReport.failure(
             metadata: _imageMetadata("Right (Constrained)"),
@@ -45,8 +50,13 @@ void main() {
               screenshot: rightCandidate,
               mismatchPixelCount: 220,
             ),
+            goldenFilePath: "/project/test_goldens/preferred_position_aligner.png",
+            failureFilePaths: ["/project/test_goldens/failures/failure_preferred_position_aligner_right.png"],
           ),
-          GoldenReport.success(_imageMetadata("Bottom (Constrained)")),
+          GoldenReport.success(
+            _imageMetadata("Bottom (Constrained)"),
+            goldenFilePath: "/project/test_goldens/preferred_position_aligner.png",
+          ),
         ],
         missingCandidates: const [],
         extraCandidates: const [],
@@ -60,11 +70,6 @@ void main() {
       final output = StringBuffer();
       GoldenSceneReportPrinter().printReport(
         report,
-        goldenFilePath: "/project/test_goldens/preferred_position_aligner.png",
-        failureFilePaths: [
-          "/project/test_goldens/failures/failure_preferred_position_aligner_top.png",
-          "/project/test_goldens/failures/failure_preferred_position_aligner_right.png",
-        ],
         output: output,
       );
       reporter.printSummary(output: output);


### PR DESCRIPTION
[Adjustment] - Add more reporting to test output to help locate failure files and to summarize overall test run (Resolves #64)

Example output after this PR:

```
Golden scene failed (✅ 2/4, ❌ 2/4):
Scene: Follower > preferred position aligner > not enough space on either side
Golden file: /project/test_goldens/preferred_position_aligner.png
Failure scenes:
  - /project/test_goldens/failures/failure_preferred_position_aligner_top.png
  - /project/test_goldens/failures/failure_preferred_position_aligner_right.png

✅ Left (Constrained)
❌ Top (Constrained) (240px, 2.40%)
❌ Right (Constrained) (220px, 2.20%)
✅ Bottom (Constrained)

Golden Tests: 34 Passed, 12 Failed
```