### PR TITLE
Revert: Bring back font loading in each test runner

### DIFF
--- a/lib/src/test_runner/test_runners.dart
+++ b/lib/src/test_runner/test_runners.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_test_goldens/src/fonts/fonts.dart';
 import 'package:flutter_test_goldens/src/test_runner/test_run_reporter.dart';
 import 'package:meta/meta.dart';
 
@@ -247,7 +248,9 @@ void testGoldenScene(
   TestVariant<Object?> variant = const DefaultTestVariant(),
   dynamic tags,
   int? retry,
-}) {
+}) async {
+  await TestFonts.loadAppFonts();
+
   if (!_didRegisterGoldenTestRunSummary) {
     _didRegisterGoldenTestRunSummary = true;
 


### PR DESCRIPTION
Revert: Bring back font loading in each test runner

I previously moved font loading from test runners to the gallery. This caused unintended consequences. I'm leaving the font loading in the gallery, but bringing back font loading in test runners.

If, in the future, we remember why I removed it from test runners, or we find a place to do it that doesn't break existing expectations, we can try again.